### PR TITLE
Map Editor selects default layer when non selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Steps:
 
 ### v0.1.1 (not released yet)
 - Improve the resilience of the tooltip of the Vega charts and allow more than two values to be displayed at once
+- Fix layer selector on map to use default value from layers list if non selected
 
 ### v0.1.0
 - Fix a bug that prevented map widgets from being restored

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Steps:
 
 ### v0.1.1 (not released yet)
 - Improve the resilience of the tooltip of the Vega charts and allow more than two values to be displayed at once
-- Fix layer selector on map to use default value from layers list if non selected
+- Autoselect the default layer, if present, in the `MapEditor` component
 
 ### v0.1.0
 - Fix a bug that prevented map widgets from being restored

--- a/src/components/map/MapEditor.js
+++ b/src/components/map/MapEditor.js
@@ -23,6 +23,8 @@ class MapEditor extends React.Component {
   render() {
     const { widgetEditor, layers, mode, showSaveButton, provider } = this.props;
     const { layer } = widgetEditor;
+    const defaultLayer = layers.find(l => l.default);
+    const defaultLayerId = defaultLayer && defaultLayer.id;
 
     const canSave = canRenderChart(widgetEditor, provider);
     const canShowSaveButton = showSaveButton && canSave;
@@ -36,8 +38,8 @@ class MapEditor extends React.Component {
           <Select
             properties={{
               name: 'layer-selector',
-              value: layer && layer.id,
-              default: layer && layer.id
+              value: layer ? layer.id : defaultLayerId,
+              default: layer ? layer.id : defaultLayerId
             }}
             options={layers.map(val => (
               {

--- a/src/components/map/MapEditor.js
+++ b/src/components/map/MapEditor.js
@@ -14,6 +14,17 @@ import Select from 'components/form/SelectInput';
 import { canRenderChart } from 'helpers/WidgetHelper';
 
 class MapEditor extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // If a default layer is present, we'll select
+    // it by default
+    const defaultLayer = props.layers.find(l => l.default);
+    if (defaultLayer) {
+      props.showLayer(defaultLayer);
+    }
+  }
+
   @Autobind
   handleLayerChange(layerID) {
     this.props.showLayer(this.props.layers.find(val => val.id === layerID));
@@ -22,8 +33,6 @@ class MapEditor extends React.Component {
   render() {
     const { widgetEditor, layers, mode, showSaveButton, provider } = this.props;
     const { layer } = widgetEditor;
-    const defaultLayer = layers.find(l => l.default);
-    const defaultLayerId = defaultLayer && defaultLayer.id;
 
     const canSave = canRenderChart(widgetEditor, provider);
     const canShowSaveButton = showSaveButton && canSave;
@@ -37,8 +46,8 @@ class MapEditor extends React.Component {
           <Select
             properties={{
               name: 'layer-selector',
-              value: layer ? layer.id : defaultLayerId,
-              default: layer ? layer.id : defaultLayerId
+              value: layer && layer.id,
+              default: layer && layer.id
             }}
             options={layers.map(val => (
               {

--- a/src/components/map/MapEditor.js
+++ b/src/components/map/MapEditor.js
@@ -6,7 +6,6 @@ import Autobind from 'autobind-decorator';
 import { connect } from 'react-redux';
 
 import { showLayer } from 'reducers/widgetEditor';
-import { toggleModal, setModalOptions } from 'reducers/modal';
 
 // Components
 import Select from 'components/form/SelectInput';
@@ -71,10 +70,7 @@ MapEditor.propTypes = {
   /**
    * Dataset ID
    */
-  datasetId: PropTypes.string.isRequired,
-  datasetType: PropTypes.string,
   layers: PropTypes.array.isRequired,
-  tableName: PropTypes.string.isRequired,
   provider: PropTypes.string.isRequired,
   mode: PropTypes.oneOf(['save', 'update']),
   /**
@@ -90,15 +86,12 @@ MapEditor.propTypes = {
 
   // Store
   showLayer: PropTypes.func.isRequired,
-  widgetEditor: PropTypes.object.isRequired,
-  toggleModal: PropTypes.func.isRequired
+  widgetEditor: PropTypes.object.isRequired
 };
 
 const mapStateToProps = ({ widgetEditor }) => ({ widgetEditor });
 const mapDispatchToProps = dispatch => ({
-  showLayer: layer => dispatch(showLayer(layer)),
-  toggleModal: (...args) => { dispatch(toggleModal(...args)); },
-  setModalOptions: (...args) => { dispatch(setModalOptions(...args)); }
+  showLayer: layer => dispatch(showLayer(layer))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(MapEditor);


### PR DESCRIPTION
## Overview

Simple fix/update to the MapEditor component to select the default layer when populating the Selector if no layer is passed.

## Testing instructions
Dataset: `815eaa09-d626-495e-91e2-523cb07de475`

## Pivotal task
https://www.pivotaltracker.com/story/show/153453357

