### PR TITLE
add title to props so parent can access

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Name | Default value | Mandatory | Description
 -----|---------------|-----------|------------
 `datasetId: string` | `undefined` | Yes | The ID of the dataset to load the data from
 `widgetId: string` | `undefined` | No | If provided, the ID of the widget to edit
+`widgetTitle: string` | `undefined` | No | If provided, the title of the widget to edit
 `saveButtonMode: string` | `"auto"` | No | If `"auto"`, the save/update button only appears if a user token is passed to the configuration. If `"always"`, the button is always shown. If `"never"`, the button never appears. **(1)**
 `embedButtonMode: string` | `"auto"` | No | If `"auto"`, the embed button only appears if a user token is passed to the configuration. If `"always"`, the button is always shown. If `"never"`, the button never appears. **(2)**
 `titleMode: string` | `"auto"` | No | If `"auto"`, the title is only editable if a user token is passed to the configuration. If `"always"`, the title is always editable. If `"never"`, it is always fixed.
@@ -260,6 +261,7 @@ Steps:
 
 ### v0.1.1 (not released yet)
 - Improve the resilience of the tooltip of the Vega charts and allow more than two values to be displayed at once
+- Show 'save' not 'update' when viewing default widgets in explore
 - Autoselect the default layer, if present, in the `MapEditor` component
 
 ### v0.1.0

--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ Name | Default value | Mandatory | Description
 -----|---------------|-----------|------------
 `datasetId: string` | `undefined` | Yes | The ID of the dataset to load the data from
 `widgetId: string` | `undefined` | No | If provided, the ID of the widget to edit
-`widgetTitle: string` | `undefined` | No | If provided, the title of the widget to edit
+`widgetTitle: string` | `undefined` | No | If provided, the title of the widget to edit. Use in conjunction with `onChangeWidgetTitle` to get a controlled input.
 `saveButtonMode: string` | `"auto"` | No | If `"auto"`, the save/update button only appears if a user token is passed to the configuration. If `"always"`, the button is always shown. If `"never"`, the button never appears. **(1)**
 `embedButtonMode: string` | `"auto"` | No | If `"auto"`, the embed button only appears if a user token is passed to the configuration. If `"always"`, the button is always shown. If `"never"`, the button never appears. **(2)**
 `titleMode: string` | `"auto"` | No | If `"auto"`, the title is only editable if a user token is passed to the configuration. If `"always"`, the title is always editable. If `"never"`, it is always fixed.
 `mapConfig: object` | `{ zoom: 3, lat: 0, lng: 0 }` | No | Default state of the map. You can specify its `zoom`, `lat` and `lng`.
 `onSave: function` | `undefined` | No | Callback executed when the user clicks the save/update button.
 `onEmbed: function` | `undefined` | No | Callback executed when the user clicks the embed button. The first argument is the type of visualization to embed.
+`onChangeWidgetTitle: function` | `undefined` | No | Callback executed when the title of the widget is changed. The first argument is the new value.
 `provideWidgetConfig: function` | `undefined` | No | Callback which is passed a function to get the widget configuration (see below)
 
 **(1)** The button is **never** shown a widget hasn't been rendered yet.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Steps:
 - Improve the resilience of the tooltip of the Vega charts and allow more than two values to be displayed at once
 - Show 'save' not 'update' when viewing default widgets in explore
 - Autoselect the default layer, if present, in the `MapEditor` component
+- Let the title of the widget being controlled from the outside
 
 ### v0.1.0
 - Fix a bug that prevented map widgets from being restored

--- a/src/components/WidgetEditor.js
+++ b/src/components/WidgetEditor.js
@@ -965,6 +965,9 @@ class WidgetEditor extends React.Component {
   handleTitleChange(event) {
     const title = event.target.value;
     this.props.setTitle(title);
+    if (this.props.onChangeWidgetTitle) {
+      this.props.onChangeWidgetTitle(title);
+    }
   }
 
   /**
@@ -1258,6 +1261,11 @@ WidgetEditor.propTypes = {
    * to get the widget config
    */
   provideWidgetConfig: PropTypes.func,
+  /**
+   * Callback executed when the value of the title is updated
+   * The callback gets passed the new value
+   */
+  onChangeWidgetTitle: PropTypes.func,
   // Store
   band: PropTypes.object,
   widgetEditor: PropTypes.object.isRequired,

--- a/src/components/WidgetEditor.js
+++ b/src/components/WidgetEditor.js
@@ -217,6 +217,13 @@ class WidgetEditor extends React.Component {
           : []
       });
     }
+
+    // If the title is controlled from the outside and
+    // its value is changed, then we update the store
+    if (nextProps.widgetTitle !== undefined
+      && nextProps.widgetTitle !== this.props.widgetEditor.title) {
+      this.props.setTitle(nextProps.widgetTitle);
+    }
   }
 
   componentDidUpdate(previousProps, previousState) {
@@ -436,9 +443,8 @@ class WidgetEditor extends React.Component {
       datasetProvider
     } = this.state;
 
-    const { widgetEditor, datasetId, selectedVisualizationType, widgetTitle } = this.props;
-    const { chartType, layer, zoom, latLng } = widgetEditor;
-    const title = widgetTitle || widgetEditor.title;
+    const { widgetEditor, datasetId, selectedVisualizationType } = this.props;
+    const { chartType, layer, zoom, latLng, title } = widgetEditor;
 
     let chartTitle = (
       <div className="chart-title">

--- a/src/components/WidgetEditor.js
+++ b/src/components/WidgetEditor.js
@@ -436,12 +436,13 @@ class WidgetEditor extends React.Component {
       datasetProvider
     } = this.state;
 
-    const { widgetEditor, datasetId, selectedVisualizationType } = this.props;
+    const { widgetEditor, datasetId, selectedVisualizationType, widgetTitle } = this.props;
     const { chartType, layer, zoom, latLng } = widgetEditor;
+    const title = widgetTitle || widgetEditor.title;
 
     let chartTitle = (
       <div className="chart-title">
-        <span>{widgetEditor.title}</span>
+        <span>{title}</span>
       </div>
     );
     if (this.props.titleMode === 'always'
@@ -450,7 +451,7 @@ class WidgetEditor extends React.Component {
         <div className="chart-title">
           <AutosizeInput
             name="widget-title"
-            value={widgetEditor.title || ''}
+            value={title || ''}
             placeholder="Widget title"
             onChange={this.handleTitleChange}
           />
@@ -1198,6 +1199,10 @@ WidgetEditor.propTypes = {
    * Widget ID (if the editor is used to edit an existing  widget)
    */
   widgetId: PropTypes.string,
+  /**
+   * Widget title (if the editor is used to edit an existing  widget)
+   */
+  widgetTitle: PropTypes.string,
   /**
    * List of visualizations that are available to the widget editor
    */

--- a/src/components/modal/SaveWidgetModal.js
+++ b/src/components/modal/SaveWidgetModal.js
@@ -54,6 +54,19 @@ class SaveWidgetModal extends React.Component {
     };
   }
 
+  /**
+   * Event handler executed when the user changes the
+   * title of the widget
+   * @param {string} event
+   */
+  @Autobind
+  onChangeTitle(title) {
+    this.props.setTitle(title);
+    if (this.props.onChangeWidgetTitle) {
+      this.props.onChangeWidgetTitle(title);
+    }
+  }
+
 
   @Autobind
   async onSubmit(event) {
@@ -139,7 +152,7 @@ class SaveWidgetModal extends React.Component {
             <fieldset className="c-we-field-container">
               <Field
                 ref={(c) => { if (c) FORM_ELEMENTS.elements.title = c; }}
-                onChange={value => this.props.setTitle(value)}
+                onChange={this.onChangeTitle}
                 validations={['required']}
                 properties={{
                   title: 'title',
@@ -229,6 +242,11 @@ SaveWidgetModal.propTypes = {
    * button to check their widgets
    */
   onClickCheckWidgets: PropTypes.func,
+  /**
+   * Callback executed when the value of the title is updated
+   * The callback gets passed the new value
+   */
+  onChangeWidgetTitle: PropTypes.func,
 
   // Store
   widgetEditor: PropTypes.object.isRequired,

--- a/test.js
+++ b/test.js
@@ -66,7 +66,8 @@ class App extends React.Component {
         childrenProps: {
           datasetId: this.state.datasetId,
           getWidgetConfig: this.getWidgetConfig,
-          onClickCheckWidgets: () => alert('Check my widgets')
+          onClickCheckWidgets: () => alert('Check my widgets'),
+          onChangeWidgetTitle: title => this.setState({ widgetTitle: title })
         }
       });
     }

--- a/test.js
+++ b/test.js
@@ -49,7 +49,7 @@ class App extends React.Component {
     this.state = {
       datasetId: '0b9f0100-ce5b-430f-ad8f-3363efa05481',
       widgetId: undefined,
-      widgetTitle: undefined
+      widgetTitle: ''
     };
   }
 
@@ -129,6 +129,7 @@ class App extends React.Component {
           titleMode="always"
           onSave={() => this.onSave()}
           onEmbed={() => this.onEmbed()}
+          onChangeWidgetTitle={title => this.setState({ widgetTitle: title })}
           provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}
         />
       </div>

--- a/test.js
+++ b/test.js
@@ -48,7 +48,8 @@ class App extends React.Component {
     super(props);
     this.state = {
       datasetId: '0b9f0100-ce5b-430f-ad8f-3363efa05481',
-      widgetId: undefined
+      widgetId: undefined,
+      widgetTitle: undefined
     };
   }
 
@@ -105,6 +106,15 @@ class App extends React.Component {
               value={this.state.widgetId}
               onChange={({ target }) => this.setState({ widgetId: target.value })}
             />
+            <br />
+            <label htmlFor="title">Widget title (optional):</label>
+            <input
+              type="text"
+              placeholder="Title of the widget"
+              id="title"
+              value={this.state.widgetTitle}
+              onChange={({ target }) => this.setState({ widgetTitle: target.value })}
+            />
           </p>
         </div>
         <Icons />
@@ -113,8 +123,10 @@ class App extends React.Component {
         <WidgetEditor
           datasetId={this.state.datasetId}
           widgetId={this.state.widgetId}
+          widgetTitle={this.state.widgetTitle}
           saveButtonMode="always"
           embedButtonMode="always"
+          titleMode="always"
           onSave={() => this.onSave()}
           onEmbed={() => this.onEmbed()}
           provideWidgetConfig={(func) => { this.getWidgetConfig = func; }}


### PR DESCRIPTION
## Overview
Adds the ability to update the title within the widget editor from the props. This will need updating in the parent components.

## Pivotal task
https://www.pivotaltracker.com/story/show/154395702