### PR TITLE
Save and restore the bounding box of layers and widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Steps:
 
 ### v0.1.3
 - Remove unused CSS rules that would interfere with the styles of RW or Prep
+- Auto-pan to the bounding box of a layer, if provided
+- Save and restore the bounding box of the widgets
 
 ### v0.1.2
 - Fix a bug where the save button would appear with the table visualization and throw a controlled error when the user tries to get its config

--- a/src/components/WidgetEditor.js
+++ b/src/components/WidgetEditor.js
@@ -890,7 +890,7 @@ class WidgetEditor extends React.Component {
     widgetService.fetchData()
       .then((data) => {
         const { widgetConfig, name } = data.attributes;
-        const { paramsConfig, zoom, lat, lng } = widgetConfig;
+        const { paramsConfig, zoom, lat, lng, bbox } = widgetConfig;
         const {
           visualizationType,
           band,
@@ -943,6 +943,7 @@ class WidgetEditor extends React.Component {
         }
         if (zoom) this.props.setZoom(zoom);
         if (lat && lng) this.props.setLatLng({ lat, lng });
+        if (bbox) this.props.setBounds([[bbox[1], bbox[0]], [bbox[3], bbox[2]]]);
       });
   }
 
@@ -1174,6 +1175,7 @@ class WidgetEditor extends React.Component {
               && (
                 <MapEditor
                   datasetId={datasetId}
+                  widgetId={widgetId}
                   tableName={tableName}
                   provider={datasetProvider}
                   datasetType={datasetType}
@@ -1230,6 +1232,7 @@ const mapDispatchToProps = dispatch => ({
   },
   setZoom: (...params) => dispatch(setZoom(...params)),
   setLatLng: (...params) => dispatch(setLatLng(...params)),
+  setBounds: (...params) => dispatch(setBounds(...params)),
   setFilters: filter => dispatch(setFilters(filter)),
   setColor: filter => dispatch(setColor(filter)),
   setCategory: filter => dispatch(setCategory(filter)),
@@ -1337,6 +1340,7 @@ WidgetEditor.propTypes = {
   setMapParams: PropTypes.func,
   setZoom: PropTypes.func,
   setLatLng: PropTypes.func,
+  setBounds: PropTypes.func,
   setFilters: PropTypes.func,
   setColor: PropTypes.func,
   setCategory: PropTypes.func,

--- a/src/components/WidgetEditor.js
+++ b/src/components/WidgetEditor.js
@@ -18,6 +18,7 @@ import {
   setCaption,
   setZoom,
   setLatLng,
+  setBounds,
   setFilters,
   setColor,
   setCategory,
@@ -448,7 +449,7 @@ class WidgetEditor extends React.Component {
     } = this.state;
 
     const { widgetEditor, datasetId, selectedVisualizationType } = this.props;
-    const { chartType, layer, zoom, latLng, title, caption } = widgetEditor;
+    const { chartType, layer, zoom, latLng, bounds, title, caption } = widgetEditor;
 
     let chartTitle = <div>{title}</div>;
     if (this.props.titleMode === 'always'
@@ -546,7 +547,8 @@ class WidgetEditor extends React.Component {
         if (layer) {
           const mapConfig = {
             zoom,
-            latLng
+            latLng,
+            bounds
           };
 
           visualization = (
@@ -1221,9 +1223,10 @@ const mapDispatchToProps = dispatch => ({
   toggleTooltip: (...params) => dispatch(toggleTooltip(...params)),
   setTitle: title => dispatch(setTitle(title)),
   setCaption: caption => dispatch(setCaption(caption)),
-  setMapParams: (params) => {
-    dispatch(setZoom(params.zoom));
-    dispatch(setLatLng(params.latLng));
+  setMapParams: ({ zoom, latLng, bounds }) => {
+    dispatch(setZoom(zoom));
+    dispatch(setLatLng(latLng));
+    if (bounds) dispatch(setBounds(bounds));
   },
   setZoom: (...params) => dispatch(setZoom(...params)),
   setLatLng: (...params) => dispatch(setLatLng(...params)),

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 import { BASEMAPS, LABELS } from 'components/map/constants';
 
 // Components
@@ -16,12 +17,7 @@ import Spinner from 'components/ui/Spinner';
 const L = (typeof window !== 'undefined') ? require('leaflet') : null;
 
 const MAP_CONFIG = {
-  zoom: 2,
   minZoom: 2,
-  latLng: {
-    lat: 30,
-    lng: -120
-  },
   zoomControl: true
 };
 
@@ -35,75 +31,38 @@ class Map extends React.Component {
 
   componentDidMount() {
     this.hasBeenMounted = true;
-
-    const mapOptions = Object.assign({}, MAP_CONFIG, this.props.mapConfig || {});
-    mapOptions.center = [mapOptions.latLng.lat, mapOptions.latLng.lng];
-
-    if (!this.mapNode) return;
-
-    this.map = L.map(this.mapNode, mapOptions);
-
-    if (this.props.setMapInstance) {
-      this.props.setMapInstance(this.map);
-    }
-
-    if (this.props.mapConfig && this.props.mapConfig.bounds) {
-      this.fitBounds(this.props.mapConfig.bounds.geometry);
-    }
-
-    // Disable interaction if necessary
-    if (!this.props.interactionEnabled) {
-      this.map.dragging.disable();
-      this.map.touchZoom.disable();
-      this.map.doubleClickZoom.disable();
-      this.map.scrollWheelZoom.disable();
-      this.map.boxZoom.disable();
-      this.map.keyboard.disable();
-    }
-
-    // SETTERS
-    this.setAttribution();
-    this.setZoomControl();
-    this.setBasemap(this.props.basemap);
-    this.setMapEventListeners();
-
-    this.setLabels(this.props.labels);
-
-    // Add layers
-    this.setLayerManager();
-    const layers = this.props.layerGroups
-      .filter(l => l.visible)
-      .map(l => l.layers.find(la => la.active));
-    this.addLayers(layers, this.props.filters);
+    this.instantiateMap();
   }
 
   componentWillReceiveProps(nextProps) {
-    const filtersChanged = !isEqual(nextProps.filters, this.props.filters);
-
     const layerGroups = this.props.layerGroups.filter(l => l.visible);
     const nextLayerGroups = nextProps.layerGroups.filter(l => l.visible);
 
     const layerGroupsChanged = !isEqual(layerGroups, nextLayerGroups);
 
     const opacities = layerGroups.map(d => ({
-      dataset: d.dataset, opacity: d.layers[0].opacity !== undefined ? d.layers[0].opacity : 1
+      dataset: d.dataset,
+      opacity: d.layers[0].opacity !== undefined
+        ? d.layers[0].opacity
+        : 1
     }));
     const nextOpacities = nextLayerGroups.map(d => ({
-      dataset: d.dataset, opacity: d.layers[0].opacity !== undefined ? d.layers[0].opacity : 1
+      dataset: d.dataset,
+      opacity: d.layers[0].opacity !== undefined
+        ? d.layers[0].opacity
+        : 1
     }));
 
-    if (!isEqual(opacities, nextOpacities)) {
-      // Set opacity if changed
-      const nextLayers = nextLayerGroups
-        .map(l => l.layers.find(la => la.active));
+    const opacitiesChanged = !isEqual(opacities, nextOpacities);
+
+    if (opacitiesChanged) {
+      const nextLayers = nextLayerGroups.map(l => l.layers.find(la => la.active));
       this.layerManager.setOpacity(nextLayers);
     }
 
-    if (filtersChanged || layerGroupsChanged) {
-      const layers = layerGroups
-        .map(l => l.layers.find(la => la.active));
-      const nextLayers = nextLayerGroups
-        .map(l => l.layers.find(la => la.active));
+    if (layerGroupsChanged) {
+      const layers = layerGroups.map(l => l.layers.find(la => la.active));
+      const nextLayers = nextLayerGroups.map(l => l.layers.find(la => la.active));
 
       const layersIds = layers.map(l => l.id);
       const nextLayersIds = nextLayers.map(l => l.id);
@@ -128,15 +87,22 @@ class Map extends React.Component {
     if (this.props.basemap !== nextProps.basemap) {
       this.setBasemap(nextProps.basemap);
     }
+
     if (this.props.labels !== nextProps.labels) {
       this.setLabels(nextProps.labels);
+    }
+
+    // We automatically pan to the bounds if they are provided
+    // or updated
+    if ((!this.props.mapConfig.bounds && nextProps.mapConfig.bounds)
+      || (nextProps.mapConfig && this.props.mapConfig.bounds !== nextProps.mapConfig.bounds)) {
+      this.map.fitBounds(nextProps.mapConfig.bounds);
     }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     const loadingChanged = this.state.loading !== nextState.loading;
-    const offsetChanged = this.props.horizontalOffset !== nextProps.horizontalOffset;
-    return loadingChanged || offsetChanged;
+    return loadingChanged;
   }
 
   componentWillUnmount() {
@@ -148,9 +114,172 @@ class Map extends React.Component {
     if (this.map) this.map.remove();
   }
 
+  /**
+   * Event handler executed when the state of
+   * the map has changed
+   */
+  onMapChange() {
+    this.props.setMapParams(this.getMapParams());
+  }
 
-  // SETTERS
-  setLayerManager() {
+  /**
+   * Return the map options of the map for
+   * its instantiation
+   * @returns {object}
+   */
+  getMapOptions() {
+    const mapOptions = Object.assign(
+      {},
+      MAP_CONFIG,
+      pick(this.props.mapConfig, ['zoom']) || {}
+    );
+
+    mapOptions.center = [this.props.mapConfig.latLng.lat, this.props.mapConfig.latLng.lng];
+
+    return mapOptions;
+  }
+
+  /**
+   * Set the map's basemap
+   * @param {{ id: string, value: string, label: string, options: object }} basemap Basemap
+   */
+  setBasemap(basemap) {
+    if (this.tileLayer) this.tileLayer.remove();
+
+    this.tileLayer = L.tileLayer(basemap.value, basemap.options)
+      .addTo(this.map)
+      .setZIndex(0);
+  }
+
+  /**
+   * Toggle the map's labels
+   * @param {boolean} showLabels Whether to show the labels
+   */
+  setLabels(showLabels) {
+    if (this.labelLayer && !showLabels) this.labelLayer.remove();
+
+    if (showLabels) {
+      this.labelLayer = L.tileLayer(LABELS.value, LABELS.options || {})
+        .addTo(this.map)
+        .setZIndex(this.props.layerGroups.length + 1);
+    }
+  }
+
+  /**
+   * Return the state of the map
+   * @returns {{ zoom: number, latLng: number[], bounds: any }}
+   */
+  getMapParams() {
+    const bounds = this.map.getBounds();
+    const params = {
+      zoom: this.map.getZoom(),
+      latLng: this.map.getCenter(),
+      bounds: [
+        [bounds.getSouthWest().lat, bounds.getSouthWest().lng],
+        [bounds.getNorthEast().lat, bounds.getNorthEast().lng]
+      ]
+    };
+    return params;
+  }
+
+  /**
+   * Set the event listeners for the map
+   */
+  setEventListeners() {
+    if (this.props.setMapParams) {
+      this.map.on('zoomend', () => this.onMapChange());
+      this.map.on('dragend', () => this.onMapChange());
+    }
+  }
+
+  /**
+   * Remove the event handlers associated with
+   * the map
+   */
+  removeMapEventListeners() {
+    this.map.off('zoomend');
+    this.map.off('dragend');
+  }
+
+  /**
+   * Add layers to the map
+   * @param {object[]} layers List of layers
+   */
+  addLayers(layers) {
+    if (!layers) return;
+
+    this.setState({ loading: true });
+    layers.forEach((layer) => {
+      this.layerManager.addLayer(layer, {
+        zIndex: layer.order
+      });
+    });
+  }
+
+  /**
+   * Remove a layer from the map
+   * If any paramater is passed, all the layers are removed
+   * @param {object} [layer] Layer to remove
+   */
+  removeLayer(layer) {
+    if (layer) {
+      this.layerManager.removeLayer(layer.id);
+    } else {
+      this.layerManager.removeLayers();
+    }
+  }
+
+  /**
+   * Instantiate the map
+   */
+  instantiateMap() {
+    if (!this.mapNode) return;
+
+    this.map = L.map(this.mapNode, this.getMapOptions());
+
+    // If the layer has bounds, we just pan in the
+    // area
+    if (this.props.mapConfig.bounds) {
+      this.map.fitBounds(this.props.mapConfig.bounds);
+    }
+
+    // Disable interaction if necessary
+    if (!this.props.interactionEnabled) {
+      this.map.dragging.disable();
+      this.map.touchZoom.disable();
+      this.map.doubleClickZoom.disable();
+      this.map.scrollWheelZoom.disable();
+      this.map.boxZoom.disable();
+      this.map.keyboard.disable();
+    }
+
+    this.map.attributionControl.addAttribution('&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>');
+    if (this.map.zoomControl) {
+      this.map.zoomControl.setPosition('topright');
+    }
+
+    // We set the current basemap and labels
+    this.setBasemap(this.props.basemap);
+    this.setLabels(this.props.labels);
+
+    // We add the event listeners
+    this.setEventListeners();
+
+
+    // Add layers
+    this.instantiateLayerManager();
+
+    const layers = this.props.layerGroups
+      .filter(l => l.visible)
+      .map(l => l.layers.find(la => la.active));
+
+    this.addLayers(layers);
+  }
+
+  /**
+   * Instantiate the layer manager
+   */
+  instantiateLayerManager() {
     const stopLoading = () => {
       // Don't execute callback if component has been unmounted
       if (!this.hasBeenMounted) return;
@@ -163,102 +292,10 @@ class Map extends React.Component {
     });
   }
 
-  setAttribution() {
-    this.map.attributionControl.addAttribution('&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>');
-  }
-
-  setZoomControl() {
-    if (this.map.zoomControl) {
-      this.map.zoomControl.setPosition('topright');
-    }
-  }
-
-  setBasemap(basemap) {
-    if (this.tileLayer) this.tileLayer.remove();
-
-    this.tileLayer = L.tileLayer(basemap.value, basemap.options)
-      .addTo(this.map)
-      .setZIndex(0);
-  }
-
-  setLabels(enabled) {
-    if (this.labelLayer && !enabled) this.labelLayer.remove();
-
-    if (enabled) {
-      this.labelLayer = L.tileLayer(LABELS.value, LABELS.options || {})
-        .addTo(this.map)
-        .setZIndex(this.props.layerGroups.length + 1);
-    }
-  }
-
-  // GETTERS
-  getMapParams() {
-    const params = {
-      zoom: this.getZoom(),
-      latLng: this.getCenter()
-    };
-    return params;
-  }
-
-  // MAP FUNCTIONS
-  getCenter() { return this.map.getCenter(); }
-
-  getZoom() { return this.map.getZoom(); }
-
-  // MAP LISTENERS
-  setMapEventListeners() {
-    function mapChangeHandler() {
-      // Dispatch the action to set the params
-      this.props.setMapParams(this.getMapParams());
-    }
-
-    if (this.props.setMapParams) {
-      this.map.on('zoomend', mapChangeHandler.bind(this));
-      this.map.on('dragend', mapChangeHandler.bind(this));
-    }
-  }
-
-  setSpinnerPosition() {
-    return this.props.horizontalOffset / 2;
-  }
-
-  fitBounds(geoJson) {
-    const geojsonLayer = L.geoJson(geoJson);
-    this.map.fitBounds(geojsonLayer.getBounds(), {
-      paddingTopLeft: [this.props.horizontalOffset || 0, 0],
-      paddingBottomRight: [0, 0]
-    });
-  }
-
-  removeMapEventListeners() {
-    this.map.off('zoomend');
-    this.map.off('dragend');
-  }
-
-  // LAYER METHODS
-  addLayers(layers, filters) {
-    if (!layers) return;
-    if (layers.length) this.setState({ loading: true });
-    layers.forEach((layer) => {
-      this.layerManager.addLayer(layer, {
-        ...(filters || this.props.filters),
-        zIndex: layer.order
-      });
-    });
-  }
-
-  removeLayer(layer) {
-    if (layer) this.layerManager.removeLayer(layer.id);
-    else this.layerManager.removeLayers();
-  }
-
-  // RENDER
   render() {
-    const spinnerStyles = { marginLeft: this.setSpinnerPosition() };
-
     return (
       <div className="c-we-map">
-        <Spinner isLoading={this.state.loading} style={spinnerStyles} />
+        <Spinner isLoading={this.state.loading} />
         <div ref={(node) => { this.mapNode = node; }} className="map-leaflet" />
       </div>
     );
@@ -267,7 +304,6 @@ class Map extends React.Component {
 
 Map.propTypes = {
   interactionEnabled: PropTypes.bool,
-  setMapInstance: PropTypes.func,
   /**
    * Selected basemap
    * @type {Basemap} basemap
@@ -279,24 +315,36 @@ Map.propTypes = {
    */
   labels: PropTypes.bool,
   /**
-   * Horizontal offset for the center of the map and
-   * loader
+   * Configuration of the map
    */
-  horizontalOffset: PropTypes.number,
-  // STORE
-  mapConfig: PropTypes.object,
-  filters: PropTypes.object,
+  mapConfig: PropTypes.shape({
+    zoom: PropTypes.number,
+    latLng: PropTypes.shape({
+      lat: PropTypes.number,
+      lng: PropTypes.number
+    }),
+    bounds: PropTypes.array
+  }),
+  /**
+   * Layer manager
+   */
   LayerManager: PropTypes.func,
-  layerGroups: PropTypes.array, // List of LayerGroup items
-  // ACTIONS
+  /**
+   * List of LayerGroup items
+   */
+  layerGroups: PropTypes.array,
+  /**
+   * Callback called with the configuration of the map
+   * each time its state is updated
+   * @type {function({ zoom: number, latLng: number[], bounds: number[][] }): any} setMapParams
+   */
   setMapParams: PropTypes.func
 };
 
 Map.defaultProps = {
   basemap: BASEMAPS.dark,
   labels: false,
-  interactionEnabled: true,
-  horizontalOffset: 0
+  interactionEnabled: true
 };
 
 export default Map;

--- a/src/components/map/MapEditor.js
+++ b/src/components/map/MapEditor.js
@@ -17,11 +17,15 @@ class MapEditor extends React.Component {
   constructor(props) {
     super(props);
 
-    // If a default layer is present, we'll select
-    // it by default
-    const defaultLayer = props.layers.find(l => l.default);
-    if (defaultLayer) {
-      this.setLayer(defaultLayer);
+    // If a widget has been restored, we don't set
+    // the default layer
+    if (!props.widgetId) {
+      // If a default layer is present, we'll select
+      // it by default
+      const defaultLayer = props.layers.find(l => l.default);
+      if (defaultLayer) {
+        this.setLayer(defaultLayer);
+      }
     }
   }
 
@@ -107,8 +111,9 @@ class MapEditor extends React.Component {
 
 MapEditor.propTypes = {
   /**
-   * Dataset ID
+   * ID of the widget, if any
    */
+  widgetId: PropTypes.string,
   layers: PropTypes.array.isRequired,
   provider: PropTypes.string.isRequired,
   mode: PropTypes.oneOf(['save', 'update']),

--- a/src/helpers/WidgetHelper.js
+++ b/src/helpers/WidgetHelper.js
@@ -715,10 +715,7 @@ export async function getWidgetConfig(
         layer_id: layer && layer.id,
         zoom,
         ...latLng,
-        ...(bounds
-          ? { bbox: [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]] }
-          : {}
-        )
+        ...bounds && { bbox: [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]] }
       };
     }
 

--- a/src/helpers/WidgetHelper.js
+++ b/src/helpers/WidgetHelper.js
@@ -679,7 +679,8 @@ export async function getWidgetConfig(
       layer,
       caption,
       zoom,
-      latLng
+      latLng,
+      bounds
     } = widgetEditor;
 
     let chartConfig = {};
@@ -707,18 +708,29 @@ export async function getWidgetConfig(
       }
     }
 
+    let additionalParams = {};
+    if (visualizationType === 'map') {
+      additionalParams = {
+        type: 'map',
+        layer_id: layer && layer.id,
+        zoom,
+        ...latLng,
+        ...(bounds
+          ? { bbox: [bounds[0][1], bounds[0][0], bounds[1][1], bounds[1][0]] }
+          : {}
+        )
+      };
+    }
+
     resolve(Object.assign(
       {},
-      // If the widget is a map, we want to add some extra info
-      // in widgetConfig so the widget is compatible with other
-      // apps that use the same API
-      // The type and layer_id are not necessary for the editor
-      // because it is already saved in widgetConfig.paramsConfig
-      (
-        visualizationType === 'map'
-          ? { type: 'map', layer_id: layer && layer.id, zoom, ...latLng }
-          : {}
-      ),
+      // Everything that is inside paramsConfig is "private" and
+      // must be *only* accessed by the widget editor.
+      // Sometimes we want some parts of the widget's configuration
+      // to be public. This includes, for example, the map's zoom,
+      // center and bounds.
+      // That's why they are saved outside of paramsConfig.
+      additionalParams,
       {
         paramsConfig: {
           visualizationType,

--- a/src/reducers/widgetEditor.js
+++ b/src/reducers/widgetEditor.js
@@ -30,6 +30,7 @@ const SET_CAPTION = 'WIDGET_EDITOR/SET_CAPTION';
 const SET_BANDS_INFO = 'WIDGET_EDITOR/SET_BANDS_INFO';
 const SET_ZOOM = 'WIDGET_EDITOR/SET_ZOOM';
 const SET_LATLNG = 'WIDGET_EDITOR/SET_LATLNG';
+const SET_BOUNDS = 'WIDGET_EDITOR/SET_BOUNDS';
 const SET_DATASET_ID = 'WIDGET_EDITOR/SET_DATASET_ID';
 const SET_TABLENAME = 'WIDGET_EDITOR/SET_TABLENAME';
 
@@ -53,10 +54,12 @@ const initialState = {
   limit: 500,
   areaIntersection: null, // ID of the geostore object
   band: null, // Band of the raster dataset
-  /** @type {{ [name: string]: { type: string, alias: string, description: string } }} */
+  /** @type {{ [name: string]: { type: string, alias: string, description: string } }} bandsInfo */
   bandsInfo: {}, // Information of the raster bands
   zoom: 3,
-  latLng: { lat: 0, lng: 0 }
+  latLng: { lat: 0, lng: 0 },
+  /** @type {number[][]} bounds */
+  bounds: null // Bounds of the map (south west, then north east)
 };
 
 export default function (state = initialState, action) {
@@ -258,6 +261,12 @@ export default function (state = initialState, action) {
       });
     }
 
+    case SET_BOUNDS: {
+      return Object.assign({}, state, {
+        bounds: action.payload
+      });
+    }
+
     case SET_DATASET_ID: {
       return Object.assign({}, state, {
         datasetId: action.payload
@@ -404,6 +413,10 @@ export function setZoom(zoom) {
 
 export function setLatLng(latLng) {
   return dispatch => dispatch({ type: SET_LATLNG, payload: latLng });
+}
+
+export function setBounds(bounds) {
+  return dispatch => dispatch({ type: SET_BOUNDS, payload: bounds });
 }
 
 export function setDatasetId(datasetId) {

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ const store = createStore(combineReducers(reducers), enhancer);
 setConfig({
   url: 'https://api.resourcewatch.org/v1',
   env: 'production,preproduction',
-  applications: 'rw',
+  applications: 'prep',
   authUrl: 'https://api.resourcewatch.org/auth',
   assetsPath: '/images/'
 });
@@ -47,7 +47,7 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      datasetId: '0b9f0100-ce5b-430f-ad8f-3363efa05481',
+      datasetId: '9cb2c3bc-18af-413c-9f7e-95767b56430d',
       widgetId: undefined,
       widgetTitle: '',
       widgetCaption: ''


### PR DESCRIPTION
## Overview
Here are the changes this PR brings to the editor:
- The map is automatically panned to the bounding box of the selected layer, if it has it defined as `bbox` in its `layerConfig` object
- Map widgets that are created through the editor contain a new `bbox` property in their `widgetConfig` object
- Map widgets that are edited in the editor have their bounding box restored, if present in the `widgetConfig` object

Because this change also implies the RW's and Prep's Map component restore the bounding box, two separate tasks have been created in their respective Pivotal:
- [RW's task](https://www.pivotaltracker.com/story/show/154972484)
- [Prep's one](https://www.pivotaltracker.com/story/show/154972456)

## Testing instructions
Here are several use case that have been tested:
- New map widgets contain a bounding box (see widget created on the next line)
- Widget editor opens a map widget that has a bounding box (`8592c7c5-55d8-4008-a1a9-9b6b564c0025`) and the map is panned to the area
- Widget editor opens a map widget that doesn't have a bounding box (`0b9f0100-ce5b-430f-ad8f-3363efa05481`) and the map is panned to the area using the previous lat/lng and zoom
- Widget editor opens a dataset whose layers have a bounding box (`9cb2c3bc-18af-413c-9f7e-95767b56430d`) and the map is panned to the area

## Pivotal task
None, discussed on Slack last week.
