### PR TITLE
Legend: timeline removed from widget editor. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ Steps:
 
 ## Changelog
 
+### v1.0.2
+- Remove the timeline from the legend (map only)
+
 ### v1.0.1
 - Fix a bug where the date filters wouldn't work
 - Fix an issue where the UserService would send a wrong "Authorization" header

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "react-dnd-html5-backend": "^2.5.4",
     "react-dropzone": "^4.2.3",
     "react-input-autosize": "^2.0.1",
-    "react-input-range": "^1.2.2",
     "react-redux": "^5.0.6",
     "react-redux-toastr": "^7.1.6",
     "react-select": "^1.0.0-rc.10",

--- a/src/components/ui/Legend.js
+++ b/src/components/ui/Legend.js
@@ -5,7 +5,6 @@ import isEqual from 'lodash/isEqual';
 import throttle from 'lodash/throttle';
 import sortBy from 'lodash/sortBy';
 // import { Router } from 'routes';
-import InputRange from 'react-input-range';
 
 // Redux
 import { connect } from 'react-redux';
@@ -19,8 +18,6 @@ import LayerInfoModal from 'components/modal/LayerInfoModal';
 import LayersTooltip from 'components/tooltip/LayersTooltip';
 import SliderTooltip from 'components/tooltip/SliderTooltip';
 import Button from 'components/ui/Button';
-
-const TIMELINE_INTERVAL_TIMER = 3000;
 
 const SortableItem = SortableElement(({ value }) => value);
 
@@ -64,9 +61,7 @@ class Legend extends React.PureComponent {
       opacityOptions: {},
       // Show a "tour" tooltip if the user adds a multi-layer
       // layer group for the first time
-      hasShownLayersTourTooltip: false,
-      currentStepTimeline: null,
-      isTimelinePlaying: false
+      hasShownLayersTourTooltip: false
     };
 
     // List of the layers buttons
@@ -152,7 +147,6 @@ class Legend extends React.PureComponent {
    * @param {LayerGroup} layerGroup
    */
   onRemoveLayerGroup(layerGroup) {
-    this.setState({ currentStepTimeline: null, isTimelinePlaying: false });
     this.props.removeLayerGroup(layerGroup);
   }
 
@@ -276,14 +270,6 @@ class Legend extends React.PureComponent {
     }
   }
 
-  onTimelineChange(currentValue = 0, datasetSpec) {
-    const currentLayer = datasetSpec.layers.find((l) => {
-      return new Date(l.layerConfig.dateTime).getFullYear() === parseInt(currentValue);
-    });
-    this.setState({ currentStepTimeline: currentValue });
-    this.props.setLayerGroupActiveLayer(datasetSpec.dataset, currentLayer.id); // datasetId, layerId
-  }
-
   /**
    * Return the action buttons associated to a
    * layer group
@@ -342,29 +328,6 @@ class Legend extends React.PureComponent {
     );
   }
 
-  setPlayTimeline(isPlaying, datasetSpec, minValue, maxValue) {
-    if (this.timer) clearInterval(this.timer);
-
-    if (isPlaying) {
-      this.timer = setInterval(() => {
-        if (this.state.currentStepTimeline === maxValue) {
-          clearInterval(this.timer);
-          return this.setState({ currentStepTimeline: null, isTimelinePlaying: false });
-        }
-        const currentValue = (this.state.currentStepTimeline || minValue);
-        const currentLayer = datasetSpec.layers.find((l) => {
-          return new Date(l.layerConfig.dateTime).getFullYear() === parseInt(currentValue);
-        });
-        requestAnimationFrame(() => {
-          this.props.setLayerGroupActiveLayer(datasetSpec.dataset, currentLayer.id);
-        });
-        return this.setState({ currentStepTimeline: currentValue + 1 });
-      }, TIMELINE_INTERVAL_TIMER, true);
-    }
-
-    this.setState({ isTimelinePlaying: isPlaying });
-  }
-
   /**
    * Return the list of layers
    * @returns {HTMLElement[]}
@@ -377,7 +340,7 @@ class Legend extends React.PureComponent {
       const datasetSpec = Object.assign({}, layerGroup);
       const activeLayer = datasetSpec.layers.find(l => l.active) || datasetSpec.layers[0];
 
-      datasetSpec.layers = sortBy(datasetSpec.layers, (l) => l.layerConfig.dateTime);
+      datasetSpec.layers = sortBy(datasetSpec.layers, l => l.layerConfig.dateTime);
 
       // Legend without timeline
       return (

--- a/src/components/ui/Legend.js
+++ b/src/components/ui/Legend.js
@@ -375,63 +375,9 @@ class Legend extends React.PureComponent {
 
     return this.props.layerGroups.map((layerGroup) => {
       const datasetSpec = Object.assign({}, layerGroup);
-      const activeLayer = datasetSpec.layers.find(l => l.active);
+      const activeLayer = datasetSpec.layers.find(l => l.active) || datasetSpec.layers[0];
 
       datasetSpec.layers = sortBy(datasetSpec.layers, (l) => l.layerConfig.dateTime);
-
-      // Legend with timeline
-      if (datasetSpec.dataset === 'c0c71e67-0088-4d69-b375-85297f79ee75' &&
-        datasetSpec.layers.length) {
-        const firstLayer = datasetSpec.layers[0];
-        const lastLayer = datasetSpec.layers[datasetSpec.layers.length - 1];
-        const minYear = new Date(firstLayer.layerConfig.dateTime).getFullYear();
-        const maxYear = new Date(lastLayer.layerConfig.dateTime).getFullYear();
-
-        const currentLayer = datasetSpec.layers.find((l) => {
-          const lYear = new Date(l.layerConfig.dateTime).getFullYear();
-          return lYear === (this.state.currentStepTimeline || minYear);
-        });
-
-        return (
-          <li key={datasetSpec.dataset} className="c-we-legend-unit">
-            <div className="legend-info">
-              <header className="legend-item-header">
-                <h3 className={this.props.className.color}>
-                  <span className="name">{currentLayer.name}</span>
-                </h3>
-                {this.getItemsActions(datasetSpec)}
-              </header>
-              <LegendType config={currentLayer.legendConfig} className={this.props.className} />
-
-              {/* Timeline */}
-              <div className="legend-timeline">
-                { this.state.isTimelinePlaying &&
-                  <button
-                    type="button"
-                    onClick={() => { this.setPlayTimeline(false, datasetSpec, minYear, maxYear); }}
-                  >
-                    <Icon name="icon-stop2" className="-small" />
-                  </button> }
-                { !this.state.isTimelinePlaying &&
-                  <button
-                    type="button"
-                    onClick={() => { this.setPlayTimeline(true, datasetSpec, minYear, maxYear); }}
-                  >
-                    <Icon name="icon-play3" className="-small" />
-                  </button> }
-                { !!(datasetSpec.layers.length) &&
-                  <InputRange
-                    minValue={minYear}
-                    maxValue={maxYear}
-                    value={this.state.currentStepTimeline || minYear}
-                    onChange={(value) => { this.onTimelineChange(value, datasetSpec); }}
-                  /> }
-              </div>
-            </div>
-            <DragHandle />
-          </li>
-        );
-      }
 
       // Legend without timeline
       return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,10 +381,6 @@ attr-accept@^1.0.3:
   dependencies:
     core-js "^2.5.0"
 
-autobind-decorator@^1.3.4:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-1.4.3.tgz#4c96ffa77b10622ede24f110f5dbbf56691417d1"
-
 autobind-decorator@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.1.0.tgz#4451240dbfeff46361c506575a63ed40f0e5bc68"
@@ -5791,13 +5787,6 @@ react-input-autosize@^2.0.1, react-input-autosize@^2.1.2:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
   dependencies:
-    prop-types "^15.5.8"
-
-react-input-range@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-input-range/-/react-input-range-1.3.0.tgz#f96d001631ab817417f1e26d8f9f9684b4827f59"
-  dependencies:
-    autobind-decorator "^1.3.4"
     prop-types "^15.5.8"
 
 react-redux-toastr@^7.1.6:


### PR DESCRIPTION
## Overview
This PR simply removes the timeline type from the Legend. As we are going to use Legend component from `wri-api-components` let's fix this in the future.

## Testing instructions
https://api.resourcewatch.org/v1/dataset/c0c71e67-0088-4d69-b375-85297f79ee75?includes=widget

## Pivotal task
https://www.pivotaltracker.com/story/show/155698488