### PR TITLE
Show alias tooltip immediately on hover

### DIFF
--- a/src/components/ui/ColumnBox.js
+++ b/src/components/ui/ColumnBox.js
@@ -198,10 +198,8 @@ class ColumnBox extends React.Component {
    * cursor on top of the root element
    */
   onMouseOverColumn() {
-    this.detailsTooltipTimer = setTimeout(() => {
-      this.detailsTooltipCloseOnMouseOut = true;
-      this.openDetailsTooltip();
-    }, 1500);
+    this.detailsTooltipCloseOnMouseOut = true;
+    this.openDetailsTooltip();
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR removes the timeout to display the tooltip when hovering a field box.

## Testing instructions
Simply hover over any of the field boxes.

## [Pivotal task](https://www.pivotaltracker.com/story/show/155970929)