### PR TITLE
Category and value labels rename

### DIFF
--- a/src/components/ui/CategoryContainer.js
+++ b/src/components/ui/CategoryContainer.js
@@ -40,7 +40,7 @@ class CategoryContainer extends React.Component {
     return connectDropTarget(
       <div className="c-we-column-container">
         <span className="text">
-          Category
+          Category (x)
         </span>
         <div className={containerDivClass}>
           {!category &&

--- a/src/components/ui/ValueContainer.js
+++ b/src/components/ui/ValueContainer.js
@@ -56,7 +56,7 @@ class DimensionYContainer extends React.Component {
     return connectDropTarget(
       <div className="c-we-column-container">
         <span className="text">
-          Value
+          Value (y)
         </span>
         <div className={containerDivClass}>
           {!value &&

--- a/src/css/dimensions_container.scss
+++ b/src/css/dimensions_container.scss
@@ -1,4 +1,5 @@
 .c-we-dimensions-container {
+  width: 235px;
   border-bottom: 1px solid $border-color-1;
   padding-bottom: 10px;
 


### PR DESCRIPTION
## Overview
This PR simply renames the `Category` and `Value` labels to `Category (x)` and `Value (y)`

## [Pivotal task](https://www.pivotaltracker.com/story/show/155970983)