### PR TITLE
Disable zoom on scroll by default

### DIFF
--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -236,6 +236,7 @@ class Map extends React.Component {
     if (!this.mapNode) return;
 
     this.map = L.map(this.mapNode, this.getMapOptions());
+    this.map.scrollWheelZoom.disable();
 
     // If the layer has bounds, we just pan in the
     // area
@@ -248,7 +249,6 @@ class Map extends React.Component {
       this.map.dragging.disable();
       this.map.touchZoom.disable();
       this.map.doubleClickZoom.disable();
-      this.map.scrollWheelZoom.disable();
       this.map.boxZoom.disable();
       this.map.keyboard.disable();
     }


### PR DESCRIPTION
## Overview
This PR disables the zoom for the map preview when scrolling with the mouse wheel.

## Testing instructions
Check scrolling using the wheel of the mouse whilst being over the map preview.

## [Pivotal task](https://www.pivotaltracker.com/story/show/155653604)